### PR TITLE
[chore] update image tag to 5.3 version

### DIFF
--- a/hazelcast-cluster/hazelcast.yaml
+++ b/hazelcast-cluster/hazelcast.yaml
@@ -51,7 +51,7 @@ hazelcast-common:
       value: -Dhazelcast.config=/opt/hazelcast/config/hazelcast-config.yml
       type: string
     hz-image-tag:
-      value: <- $hazelcast-image-tag default("5.2.1")
+      value: <- $hazelcast-image-tag default("5.3")
       type: string
     member1-hostname:
       type: string

--- a/hazelcast-cluster/stack.yaml
+++ b/hazelcast-cluster/stack.yaml
@@ -22,5 +22,5 @@ stack:
     - hazelcast-cluster/hazelcast-management
   variables:
     hazelcast-management-image-tag: latest
-    hazelcast-image-tag: 5.2.1
+    hazelcast-image-tag: 5.3
     cluster-name: hazelcast-cluster

--- a/hazelcast/hazelcast.yaml
+++ b/hazelcast/hazelcast.yaml
@@ -41,7 +41,7 @@ hazelcast:
       value: -Dhazelcast.config=/opt/hazelcast/config/hazelcast-config.yml
       type: string
     hz-image-tag:
-      value: <- $hazelcast-image-tag default("5.2.1")
+      value: <- $hazelcast-image-tag default("5.3")
       type: string
 
 hazelcast-management:

--- a/hazelcast/stack.yaml
+++ b/hazelcast/stack.yaml
@@ -20,5 +20,5 @@ stack:
     - hazelcast/hazelcast-management
   variables:
     hazelcast-management-image-tag: latest
-    hazelcast-image-tag: 5.2.1
+    hazelcast-image-tag: 5.3
     cluster-name: local-cluster


### PR DESCRIPTION
This pull request updates the Hazelcast image tag version across multiple configuration files to ensure consistency and use the latest version.

Version updates:

* [`hazelcast-cluster/hazelcast.yaml`](diffhunk://#diff-4c54e54ee1448f21b6a1b9fa5e63ec934a98305b8a8b06f0228f1288d774a126L54-R54): Updated the `hz-image-tag` value to use the default version "5.3" instead of "5.2.1".
* [`hazelcast-cluster/stack.yaml`](diffhunk://#diff-ab2740f765ac93fee87a1d732196773df0d993868579eacc62dd29115e6d9e8aL25-R25): Changed the `hazelcast-image-tag` variable to "5.3" from "5.2.1".
* [`hazelcast/hazelcast.yaml`](diffhunk://#diff-d7b21863762e3676003dca9cb50265eae21fbf9f1b6103ccb6ee8c2c126659c9L44-R44): Updated the `hz-image-tag` value to use the default version "5.3" instead of "5.2.1".
* [`hazelcast/stack.yaml`](diffhunk://#diff-3e256f032d56552f269d8b631a056a2bc8d6855925d82a367c70cf097ffad8b1L23-R23): Changed the `hazelcast-image-tag` variable to "5.3" from "5.2.1".